### PR TITLE
Arreglar el tamaño de los iconos para que no sobresalga de la pantalla.

### DIFF
--- a/css/tools-style.css
+++ b/css/tools-style.css
@@ -6,14 +6,14 @@
 }
 
 .tools img{
-    width: 18rem;
+    width: 80%;
     cursor: pointer;
-    margin: 0 1rem;
+    margin: 10%;
 }
 
 .all-tools h3{
     text-align: center;
-    font-size: 2rem;
+    font-size: 1rem;
     margin: 2rem;
     transition: transform 0.8s; 
 


### PR DESCRIPTION
Actualmente, los iconos de las herramientas se sobresalen de la pantalla con baja resolucion.
Con este cambio, hacemos que los iconos siempre ocupen el 80% del espacio de su contenedor.